### PR TITLE
Downgrade scala because Word2VecRawTextExample is broken on 2.11.X.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "deeplearning4j-examples-scala"
 
 version := "1.0"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.10.4"
 
 lazy val root = project.in(file("."))
 


### PR DESCRIPTION
That because dl4j-scaleout-akka depends on akka-actor_2_10 binary.
See: http://stackoverflow.com/questions/26351338/running-spark-scala-example-fails
See also: deeplearning4j-scaleout/deeplearning4j-scaleout-akka/pom.xml
