### PR TITLE
Missing "/" in local maven resolver path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,4 +23,4 @@ resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repos
 
 resolvers += "Sonatype release Repository" at "http://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
-resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository/"
+resolvers += "Local Maven Repository" at "file:///"+Path.userHome.absolutePath+"/.m2/repository/"


### PR DESCRIPTION
Missing "/" leading to a lot of "[error] URI has an authority component" when compiling with SBT. Possibly only a problem on windows.
